### PR TITLE
Fix shape of random vector multiplied with constructed "N"

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ N22 = np.eye(5)
 N = KroneckerBlock([[N11, N12], 
                     [N21, N22]])
 
-print(N @ np.random.normal(size=5 * 6 * 2))
+print(N @ np.random.normal(size=5 * 6 + 5))
 ```
 
 Block diagonal matrices can also be created in a similar way 


### PR DESCRIPTION
Original code results in 

`ValueError: other's first dimension should have length 35 to match the  dimensions of the operator, but it has length 60`

The examples in the README.md file are didactically very advantageously structured.
However, it might be advisable to make each, or at least most, code blocks self-contained.

I copied all code blocks in one file in order to be able to execute the latter code blocks....
Some blocks could be easily made self-contained by, e.g., `import numpy as np`...